### PR TITLE
Remove unused sox_effects import for torchaudio 2.9+ compatibility

### DIFF
--- a/matcher.py
+++ b/matcher.py
@@ -9,7 +9,7 @@ import torchaudio.transforms as T
 from hifigan.models import Generator as HiFiGAN
 from hifigan.utils import AttrDict
 from torch import Tensor
-from torchaudio.sox_effects import apply_effects_tensor
+#from torchaudio.sox_effects import apply_effects_tensor
 from wavlm.WavLM import WavLM
 from knnvc_utils import generate_matrix_from_index
 


### PR DESCRIPTION
The `sox_effects` module has been deprecated and removed as of torchaudio 2.9, causing an import error when used with versions >=2.9. Reference: https://docs.pytorch.org/audio/2.8/sox_effects.html

This module is not used anywhere in the file. Commenting out (or removing) the unused import resolves the compatibility issue and provides support for torchaudio 2.9+ without functional impact.
